### PR TITLE
Solved import Error of Rasterio | Solved 3 Warnings

### DIFF
--- a/get_weather_data.py
+++ b/get_weather_data.py
@@ -18,6 +18,7 @@ For this rule to work you must have
 
 """
 import logging
+from osgeo import gdal
 import atlite
 # import geopandas as gpd
 import pandas as pd

--- a/map_costs.py
+++ b/map_costs.py
@@ -8,6 +8,7 @@ Created on Thu Apr 27 11:14:48 2023
 This script visualizes the spatial cost of hydrogen for each demand center.
 """
 
+from osgeo import gdal
 import geopandas as gpd
 import cartopy.crs as ccrs
 import matplotlib.pyplot as plt

--- a/optimize_hydrogen_plant.py
+++ b/optimize_hydrogen_plant.py
@@ -9,6 +9,7 @@ hydrogen plant capacity.
 
 """
 
+from osgeo import gdal
 import atlite
 import geopandas as gpd
 import pypsa
@@ -60,9 +61,9 @@ def demand_schedule(quantity, transport_state, transport_excel_path,
     # schedule for trucking
     annual_deliveries = quantity/truck_capacity
     quantity_per_delivery = quantity/annual_deliveries
-    index = pd.date_range(start_date, end_date, periods=annual_deliveries)
+    index = pd.date_range(start_date, end_date, periods=int(annual_deliveries))
     trucking_demand_schedule = pd.DataFrame(quantity_per_delivery, index=index, columns = ['Demand'])
-    trucking_hourly_demand_schedule = trucking_demand_schedule.resample('H').sum().fillna(0.)
+    trucking_hourly_demand_schedule = trucking_demand_schedule.resample('h').sum().fillna(0.)
 
     # schedule for pipeline
     index = pd.date_range(start_date, end_date, freq = 'H')
@@ -171,7 +172,7 @@ def optimize_hydrogen_plant(wind_potential, pv_potential, times, demand_profile,
            )
     # Output results
 
-    lcoh = n.objective/(n.loads_t.p_set.sum()[0]/39.4*1000) # convert back to kg H2
+    lcoh = n.objective/(n.loads_t.p_set.sum().iloc[0]/39.4*1000) # convert back to kg H2
     wind_capacity = n.generators.p_nom_opt['Wind']
     solar_capacity = n.generators.p_nom_opt['Solar']
     electrolyzer_capacity = n.links.p_nom_opt['Electrolysis']


### PR DESCRIPTION
Initially, the model did not run for me, and I had to solve the import error. After that, it ran smoothly. 
#### Import Error of Rasterio
For me, the import of rasterio failed and gave the following error: 

``` 
from rasterio._version import gdal_version, get_geos_version, get_proj_version 
ImportError: DLL load failed while importing _version: The specified procedure could not be found.
```

I could solve it by adding the following line **before** importing other packages in the files optimize_hydrogen_plant, get_weather_data, map_costs:

```
from osgeo import gdal 
```

#### Three Warnings
Three warnings in optimize_hydrogen_plant.py solved:

- Transforming a non-integer to an integer
- Resampling is done with lowercase 'h' for hours instead of uppercase 'H'
- Accessing series by position with .iloc